### PR TITLE
fix: make monitored function alarm name readable

### DIFF
--- a/src/patterns/monitored-function/monitored-function.base.ts
+++ b/src/patterns/monitored-function/monitored-function.base.ts
@@ -52,6 +52,7 @@ export abstract class MonitoredFunctionBase<FunctionProps extends lambda.Functio
 
   private setupMonitoring() {
     const failedInvocations = new cloudwatch.Alarm(this, `FunctionInvokeErrors`, {
+      alarmName: `${this.id}FunctionInvokeErrors`,
       metric: this.function.metricErrors({period: Duration.minutes(1)}),
       threshold: 1,
       evaluationPeriods: 1,


### PR DESCRIPTION
**Description**

Make monitored function alarm name readable, especially when nested in stacks